### PR TITLE
プライバシーポリシーと行動規範を法人情報サイトに移管

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>一般社団法人DroidKaigi &rsaquo; 行動規範</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
+          integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+</head>
+<body>
+<div class="container">
+
+    <h1>行動規範</h1>
+
+    <p>DroidKaigiはAndroid技術情報の共有とコミュニケーションを目的としています。私たちはすべての参加者にとって安全で歓迎されるような場を作ることに努めます。</p>
+
+    <p>
+        DroidKaigiに参加するすべての人は下記の行動規範を守ることを求められます。主催者はこの行動規範をカンファレンス、パーティ、交流会に適用します。すべての人にとって安全な場所を提供するため、聴講者、登壇者、スポンサー、主催スタッフ含めたすべての参加者にご協力をお願いします。</p>
+
+    <p>私たちは下記のような事柄に関わらずすべての人にとって安全な場を提供することに努めます。</p>
+
+    <ul>
+        <li>社会的あるいは法的な性、性自認、性表現（外見の性）、性指向</li>
+        <li>年齢、障がい、容姿、体格</li>
+        <li>人種、民族、宗教（無宗教を含む）</li>
+        <li>技術の選択</li>
+    </ul>
+
+    <p>そして下記のようなハラスメント行為をいかなる形であっても決して許容しません。</p>
+
+    <ul>
+        <li>脅迫、つきまとい、ストーキング</li>
+        <li>不適切な画像、動画、録音の再生（性的な画像など）</li>
+        <li>発表や他のイベントに対する妨害行為</li>
+        <li>不適切な身体的接触</li>
+        <li>これらに限らない性的嫌がらせ</li>
+    </ul>
+
+    <p>スポンサーや登壇者、主催スタッフもこのポリシーの対象となります。性的な言葉や画像はいかなる発表やワークショップ、パーティ、Twitterのようなオンラインメディアにおいても不適切です。</p>
+
+    <p>ハラスメント行為をやめるように指示された場合、直ちに従うことが求められます。ルールを守らない参加者は、主催者およびスポンサーの判断により、退場処分や今後のイベントに聴講者、登壇者、スタッフとして関わることを禁止します。</p>
+
+    <p>
+        もしハラスメントを受けていると感じたり、他の誰かがハラスメントされていることに気がついた場合、または他に何かお困りのことがあれば、すぐにスタッフまでご連絡ください。警備員や警察への連絡などを含め、安心してカンファレンスに参加できるようにお手伝いさせていただきます。</p>
+
+    <hr/>
+
+    <p>この行動規範は、CC-BY-3.0で公開されている<a href="http://droidcon.nyc/code-of-conduct/">Droidcon NYCのCode of Conduct</a>を元に作成しています。
+    </p>
+
+    <p>This work is licensed under a <a href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons
+        Attribution 3.0 Unported License</a>.</p>
+
+    <p>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a
+            href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a></p>
+</div>
+</body>
+</html>

--- a/en/code-of-conduct.html
+++ b/en/code-of-conduct.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>DroidKaigi Association &rsaquo; Code of Conduct</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
+          integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+</head>
+<body>
+<div class="container">
+
+    <h1>Code of Conduct</h1>
+
+    <p>DroidKaigi is a conference tailored for developers. We aim to provide a safe, welcoming environment every participant.</p>
+
+    <p>All participants at DroigKaigi are required to agree with the following Code of Conduct. Organizers will enforce this code at the conference, party and meetup-related social events. We expect cooperation from every participant (attendees, speakers, sponsors, hosts, staff members and organizers) to ensure a safe space for everybody.</p>
+
+    <p>Our conference is dedicated to providing a safe environment for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), technology choices, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. We do not tolerate harassment of participants in any shape or form. Sponsors, speakers and hosts are also subject to the anti-harassment policy. Sexual language and imagery are not appropriate at any talks, workshops, parties, Twitter and other online media.</p>
+
+    <p>Participants asked to stop any harassing behavior are expected to comply immediately. Participants violating these rules may be removed from the conference and/or blocked from future events, at the discretion of the organizers, hosts, or sponsors.</p>
+
+    <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact one of our staff members immediately. We will be happy to help participants contact building security or police, or otherwise assist those experiencing harassment to feel safe for the duration of the conference.</p>
+
+    <hr />
+
+    <p>This work is based on <a href="http://droidcon.nyc/code-of-conduct/">Droidcon NYC Code of Conduct</a> which is licensed under CC-BY-3.0.</p>
+
+    <p>This work is licensed under a <a href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a>.</p>
+
+    <p>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a></p>
+
+</div>
+</body>
+</html>

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>DroidKaigi Association &rsaquo; Privacy Policy</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
+          integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+</head>
+<body>
+<div class="container">
+
+    <h1 id="privacy-policy-of-droidkaigi-association">Privacy Policy of DroidKaigi Association</h1>
+
+    <p class="text-danger">This is an unofficial translation. Only the original Japanese text of Privacy Policy has legal effect, and the translations are to be used solely as reference material to aid in the understanding of <a href="../privacy.html">Japanese Privacy Policy</a>.</p>
+
+    <p class="text-right">
+        Enacted on: November 19, 2016<br />
+        Last revised on: November 19, 2016<br />
+    </p>
+
+    <p>DroidKaigi Association stipulates its privacy policy as follows and shall endeavor to protect any personal information in a proper manner.</p>
+
+    <h2 id="definitions">Definitions</h2>
+
+    <ol>
+        <li>“Association” means DroidKaigi Association.</li>
+        <li>“Personal Information” means any personal information as specified in the Act on the Protection of Personal Information (Act No. 57; May 30th, 2003) (i.e., personal information of any living individual that can be used to identify the individual such as its name, address, phone number, etc.), information that is used in connection with a specific individual such as email address, SNS account, etc., and any other information on a specific individual that is an integral part of any of the aforementioned types of information.</li>
+    </ol>
+
+    <h2 id="gathering-of-personal-information">Gathering of Personal Information</h2>
+
+    <p>The Association shall only gather information that will be voluntarily provided by the users of various services to be offered by the Association as well as by concerned parties that will be involved in the review and selection processes related to the Association’s business operation, to an extent that is necessary. When gathering any Personal Information, the Association shall clearly specify the purpose and shall gather the Personal Information with the consent of those providing the Personal Information, in principle.</p>
+
+    <h2 id="use-of-personal-information">Use of Personal Information</h2>
+
+    <p>The Association shall limit the use of the Personal Information that has been provided to it to the following purposes.<br />
+        In addition, unless there are any special circumstances, the Association shall not disclose or provide the Personal Information to a third party without the consent of the individuals to which the Personal Information pertains:</p>
+
+    <ol>
+        <li>identification of individuals, provision of services concerning users’ request to use the services, billing of usage fees, and notification of any change to the service terms and conditions or of suspension or discontinuation of any service or contractual cancellation;</li>
+        <li>distribution of information on upcoming events, and provision of information that is necessary for the operation of events such as the distribution, use, etc. of the Association’s official software applications; and</li>
+        <li>other purposes besides those stated above such as provision of information on the various services that will be provided by the Association and conducting of surveys in order to improve the quality of the services that are provided by the Association.</li>
+    </ol>
+
+    <p>When it intends to use the Personal Information for any of the aforementioned purposes, the Association may use any of the following particular external services. As for how the Personal Information will be handled by the external services, please review the respective privacy policies of the external services.</p>
+
+    <ol>
+        <li>PayPal https://www.paypal.com/</li>
+        <li>Connpass http://connpass.com/</li>
+        <li>DoorKeeper https://www.doorkeeper.jp/</li>
+        <li>Google Drive https://drive.google.com</li>
+        <li>Google Analytics http://www.google.com/analytics/ <sup>*</sup></li>
+    </ol>
+
+    <p><sup>*</sup>There may be instances where anonymous user traffic data will be gathered using cookies that are provided by Google Analytics.</p>
+
+    <p>In addition, the Association may use the Personal Information for any other purposes besides those specified above or disclose or provide the Personal Information to a third party in any of the following circumstances.</p>
+
+    <ol>
+        <li>if it is required or permitted by law;</li>
+        <li>if the consent of the individual to which the Personal Information pertains has been obtained; or</li>
+        <li>if the Association is outsourcing the handling of the Personal Information, in whole or in part, to a third party to an extent that is necessary for the Association to achieve the purpose of its business operation (i.e., contracting a provider of transportation service, etc.).</li>
+    </ol>
+
+    <h2 id="management-of-personal-information">Management of Personal Information</h2>
+
+    <p>The Association shall endeavor to manage the Personal Information that it has gathered in a proper manner.</p>
+
+    <h2 id="disclosure-correction-etc-of-personal-information">Disclosure, correction, etc. of Personal Information</h2>
+
+    <p>If an individual that has previously provided its Personal Information to the Association requests the Association to disclose its Personal Information that is in the possession of the Association, the Association shall, in principle, meet such request without delay. In addition, if any individual makes a request to correct its Personal Information or take other action concerning its Personal Information that is in the possession of the Association, the Association shall, in principle, meet such request without delay.</p>
+
+    <h2 id="modification-of-the-privacy-policy">Modification of the Privacy Policy</h2>
+
+    <p>The Association reserves the right to modify its privacy policy without prior notice. If any modification is made to the privacy policy, the Association shall post the information at the website being operated by the Association without delay.</p>
+
+    <h2 id="contact-point-for-sending-inquiries-on-the-handling-of-personal-information">Contact Point for Sending Inquiries on the Handling of Personal Information</h2>
+
+    <p>If you have any question, etc. on how the Personal Information is protected by the Association, please contact us by sending an email to info@droidkaigi.jp.</p>
+</div>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>一般社団法人DroidKaigi &rsaquo; プライバシーポリシー</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
+          integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+</head>
+<body>
+<div class="container">
+    <h1 id="droidkaigi">一般社団法人DroidKaigiプライバシーポリシー</h1>
+
+    <p class="text-right">
+        制定：2016年11月19日<br/>
+        最終改訂日：2016年11月19日<br/>
+    </p>
+
+    <p>一般社団法人DroidKaigiは、プライバシーポリシーを以下のように定め、個人情報の適切な保護に努めます。</p>
+
+    <h2 id="section">定義</h2>
+
+    <ol>
+        <li>「本法人」とは一般社団法人DroidKaigiを指します。</li>
+        <li>
+            「個人情報」とは個人情報の保護に関する法律（平成十五年五月三十日法律第五十七号）に定める個人情報（生存する個人に関する情報であり、特定の個人を識別可能なものを言い、氏名、住所、電話番号等を含みます。）並びに特定の個人と結びついて使用されるメールアドレスやSNSアカウントなどの情報及びそれらと一体となった個人に関する情報を指すものとします。
+        </li>
+    </ol>
+
+    <h2 id="section-1">個人情報の収集</h2>
+
+    <p>
+        本法人は、本法人が行う各種サービスの利用者、および本法人の事業に関わる審査・選考の関係者から任意に提供される情報を必要な範囲で収集します。個人情報を収集する際は、その目的を明示するとともに、提供者の意思に基づくことを原則とします。</p>
+
+    <h2 id="section-2">個人情報の利用</h2>
+
+    <p>本法人は、提供いただいた個人情報を次の目的の範囲内で利用します。<br/>
+        また、提供いただいた個人情報は特段の事情がある場合を除き、本人の同意なく第三者へ開示提供することはありません。</p>
+
+    <ol>
+        <li>本人確認、利用申込に関するサービスの提供、利用料金の請求、及び利用サービス提供条件の変更・停止・中止・契約解除の通知</li>
+        <li>イベントの開催案内、公式アプリの配布・利用などイベント運営に関わる必要な情報の提供</li>
+        <li>上記の他、本法人の各種サービスに関する情報提供やサービス向上のための調査</li>
+    </ol>
+
+    <p>上記の目的で個人情報を利用するとき、特に次の外部サービスを利用することがあります。外部サービスにおける個人情報の取扱いについては、それぞれの外部サービスのプライバシーポリシーをご確認下さい。</p>
+
+    <ol>
+        <li>PayPal <a href="https://www.paypal.com/">https://www.paypal.com/</a></li>
+        <li>Connpass <a href="http://connpass.com/">http://connpass.com/</a></li>
+        <li>DoorKeeper <a href="https://www.doorkeeper.jp/">https://www.doorkeeper.jp/</a></li>
+        <li>Google Drive <a href="https://drive.google.com">https://drive.google.com</a></li>
+        <li>Google Analytics <a href="http://www.google.com/analytics/">http://www.google.com/analytics/</a> (※)</li>
+    </ol>
+
+    <p>(※)Google Analyticsから提供されるcookieを使用して匿名のトラフィックデータを収集することがあります。</p>
+
+    <p>また次のいずれかの場合には上記の収集目的以外に個人情報を利用し、または開示提供することがあります。</p>
+
+    <ol>
+        <li>法令の規定に基づくとき</li>
+        <li>提供者本人の同意があるとき</li>
+        <li>事業目的の達成のために必要な範囲内において個人情報の取扱いの全部又は一部を委託する場合（例えば、配送等のサービスを委託する場合など）</li>
+    </ol>
+
+    <h2 id="section-3">個人情報の管理</h2>
+
+    <p>本法人は、収集した個人情報を適切な管理するように努めます。</p>
+
+    <h2 id="section-4">個人情報の開示および訂正等</h2>
+
+    <p>本法人は、個人情報の提供者から自己に関する個人情報の開示の請求があったときは、原則として遅滞なく開示します。また、自己に関する個人情報の訂正等の申し出があったときは、原則として遅滞なく訂正等を行います。</p>
+
+    <h2 id="section-5">プライバシーポリシーの変更について</h2>
+
+    <p>本法人は、予告無くプライバシーポリシーを改定することがあります。プライバシーポリシーの改定があったときは、本法人が運営するウェブサイトに遅滞なく掲載いたします。</p>
+
+    <h2 id="section-6">個人情報の取り扱いに関する問い合わせ先</h2>
+
+    <p>本法人における個人情報保護に関してご質問などがある場合は、 info@droidkaigi.jp までご連絡下さい。</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
DroidKaigi/2017 のプライバシーポリシーと行動規範を法人サイトに移管しました。

- index.html にリンクを実装していません。特に載せる理由もなかったのでやらなかった、程度の理由ですが、指摘あればさくっとやってしまいます。
- https://github.com/DroidKaigi/2018/issues/41 はまだ反映されていません(diffみれるようにしたかった為)